### PR TITLE
Update tj-actions/changed-files to address security vulnerability

### DIFF
--- a/.github/workflows/data_tests_changed_files.yml
+++ b/.github/workflows/data_tests_changed_files.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Get changed *.csv files
       id: changed-files
-      uses: tj-actions/changed-files@v44
+      uses: tj-actions/changed-files@v45
       with:
         path: data
         files: |

--- a/.github/workflows/pull_request_comment.yml
+++ b/.github/workflows/pull_request_comment.yml
@@ -18,9 +18,10 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          run_id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Read pull request number
         id: pull_request_number_reader


### PR DESCRIPTION
This updates the version of the `tj-actions/changed-files` GitHub Action. A [security vulnerability](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) that allowed remote attackers to discover secrets existed between March 14 and March 15, 2025.

We did not appear to have any dependent builds run during that timeframe.